### PR TITLE
Added masked value for streaks feature

### DIFF
--- a/app/services/core.py
+++ b/app/services/core.py
@@ -93,7 +93,7 @@ def compute_sma(close: pd.Series, window: int = 5) -> pd.Series:
 
 # computing trend runs (up/down streaks)
 @timer
-def compute_streak(close: pd.Series) -> tuple[int, int]:
+def compute_streak(close: pd.Series) -> tuple[int, int, pd.Series]:
     """
     Compute longest upward and downward streaks of consecutive days manually.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,13 +28,20 @@ def test_compute_sma(sample_close: pd.Series) -> None:
 
 
 def test_compute_streak(sample_close: pd.Series) -> None:
-    up_streak, down_streak = compute_streak(sample_close)
+    up_streak, down_streak, mask = compute_streak(sample_close)
+    
+    # Type checks
     assert isinstance(up_streak, int)
-    assert up_streak == 99
-
     assert isinstance(down_streak, int)
+    assert isinstance(mask, pd.Series)
+
+    # Expected values (based on monotonic increasing sample_close)
+    assert up_streak == 99
     assert down_streak == 0
 
+    # Value range check for mask
+    assert all(val in (-1, 0, 1) for val in mask.unique())
+    
 
 def test_compute_sdr(sample_close: pd.Series) -> None:
     sdr: pd.Series = compute_sdr(sample_close)


### PR DESCRIPTION
As discussed, I've added the new values the initial for plotting of the up(green) and down(red) price chart movements, considered removing the total and longest streaks as its not used for visualization but the project specs had mentioned to compute these so we will keep them, some ideas on how those values can also be used to visualized:
 - Total occurrences > number of separate up runs and down runs that happened in the time series
   - Can be use in a table or text summary (e.g. 60 up runs, 55 down runs)
 - Longest streak > longest continuous run of up or down days 
   - Can be shown numerically and reflected visually (color segments on Close price plot)
   
The plotting of upward and downward movements is required while these additional recommendations can be used provided extra time. 